### PR TITLE
TECH-170: Add mock applications to bb-registration

### DIFF
--- a/examples/mock/Dockerfile
+++ b/examples/mock/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:14-alpine
+
+RUN npm install -g @mockoon/cli@2.2.1
+COPY mockoon-registration.json ./mockoon-registration.json
+
+# Do not run as root.
+RUN adduser --shell /bin/sh --disabled-password --gecos "" mockoon
+RUN chown -R mockoon ./mockoon-registration.json
+USER mockoon
+
+EXPOSE 3003
+
+ENTRYPOINT ["mockoon-cli", "start", "--hostname", "0.0.0.0", "--daemon-off", "--data", "mockoon-registration.json", "--container"]
+
+# Usage: docker run -p <host_port>:<container_port> mockoon-test

--- a/examples/mock/README.md
+++ b/examples/mock/README.md
@@ -7,7 +7,7 @@ Registration BB
 
 To run dockerized version of mocked API use shell script `test_entrypoint.sh`
 (requires `docker` and `docker-compose`). By default, API is available on port
-`3333`, application runs on port `3003` in Docker host. Dockerfile was created
+`3355`, application runs on port `3003` in Docker host. Dockerfile was created
 using mockoon-cli.
 
 ## Changes in API definition

--- a/examples/mock/README.md
+++ b/examples/mock/README.md
@@ -1,0 +1,21 @@
+# Mockoon API
+
+This is a mock application which performs the whole OpenAPI spec for
+Registration BB
+
+## Setup
+
+To run dockerized version of mocked API use shell script `test_entrypoint.sh`
+(requires `docker` and `docker-compose`). By default, API is available on port
+`3333`, application runs on port `3003` in Docker host. Dockerfile was created
+using mockoon-cli.
+
+## Changes in API definition
+
+To introduce changes in API definition it is necessary to change content of
+`mockoon-registration.json` file. It can be done using
+[mockoon application](https://mockoon.com/). After following instalation, API
+Spec can be opened from application navigation bar
+`File > Open environment > Select mockoon-registration.json`. Dockerized
+instance of application is not hot-reloaded, therefore it's necessary to restart
+server for changes to be applied.

--- a/examples/mock/docker-compose.yml
+++ b/examples/mock/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3.3'
+
+services:
+  app:
+    image: bb-registration-api-image
+    ports:
+      - 3355:3003
+    networks:
+      - web
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+    volumes:
+      - ./mockoon-registration.json:/mockoon-registration.json
+
+networks:
+  web:
+    driver: bridge

--- a/examples/mock/mockoon-registration.json
+++ b/examples/mock/mockoon-registration.json
@@ -1,0 +1,42 @@
+{
+  "uuid": "9ea8d795-abc6-4993-b4d3-a33d4a0541a0",
+  "lastMigration": 24,
+  "name": "Registration",
+  "endpointPrefix": "",
+  "latency": 0,
+  "port": 3003,
+  "hostname": "0.0.0.0",
+  "routes": [],
+  "proxyMode": false,
+  "proxyHost": "",
+  "proxyRemovePrefix": false,
+  "tlsOptions": {
+    "enabled": false,
+    "type": "CERT",
+    "pfxPath": "",
+    "certPath": "",
+    "keyPath": "",
+    "caPath": "",
+    "passphrase": ""
+  },
+  "cors": true,
+  "headers": [
+    {
+      "key": "Content-Type",
+      "value": "application/json"
+    }
+  ],
+  "proxyReqHeaders": [
+    {
+      "key": "",
+      "value": ""
+    }
+  ],
+  "proxyResHeaders": [
+    {
+      "key": "",
+      "value": ""
+    }
+  ],
+  "data": []
+}

--- a/examples/mock/test_entrypoint.sh
+++ b/examples/mock/test_entrypoint.sh
@@ -1,0 +1,1 @@
+docker-compose up app


### PR DESCRIPTION
Add mock applications to bb-registration

## Description
Generic mockoon API that is being generated based on openAPI schema was created in digital-registries building block. This example application should be copied to the bb-registration building blocks.

TICKET: https://govstack-global.atlassian.net/browse/TECH-170
